### PR TITLE
Adds support for Swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
     needs: create-matrix
     if: ${{ needs.create-matrix.outputs.matrix != '[]' }}
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ def build_languages_list(languages):
 
 # return a list of objects from language list if they are not in the exclude list
 def exclude_languages(language_list):
-    excluded = [x.strip() for x in exclude.split(',')]
+    excluded = [x.strip().lower() for x in exclude.split(',')]
     output = list(set(language_list).difference(excluded))
     print("languages={}".format(output))
     return output

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import sys
 token = sys.argv[1]
 endpoint = sys.argv[2]
 exclude = sys.argv[3]
-codeql_languages = ["cpp", "csharp", "go", "java", "javascript", "python", "ruby", "typescript", "kotlin"]
+codeql_languages = ["cpp", "csharp", "go", "java", "javascript", "python", "ruby", "typescript", "kotlin", "swift"]
 
 
 # Connect to the languages API and return languages


### PR DESCRIPTION
- Adds `swift` to codeql supported language (this maps directly to linguist api label: `Swift` )
  - case insensitivity is handled in the script, but exclude list was case sensitive... added a `lower()` case handling on that input check. 
- Update sample to highlight `swift` requires `macos-latest` runner