### PR TITLE
Bugfix for #5: Altered output breaks functionality with strategy

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ def exclude_languages(language_list):
 def set_action_output(output_name, value) :
     if "GITHUB_OUTPUT" in os.environ :
         with open(os.environ["GITHUB_OUTPUT"], "a") as f :
-            print("Detected languages: {0}={1}".format(output_name, value), file=f)
+            print("{0}={1}".format(output_name, value), file=f)
 
 def main():
     languages = get_languages()


### PR DESCRIPTION
This PR fixes the bug that was in #5 . 

The altered output from v1.1.0 gives an error when you use the output from the action in this type of context:
```    
strategy:
      fail-fast: false
      matrix:
        language: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
```
        
It cannot parse the JSON properly and thus the parsing ends in an empty value as well. This fix, which was mentioned in #5 should fix that.

Credit to the proposed fix by @gurucloudsec